### PR TITLE
Revert timezone "cast" for now

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -83,7 +83,7 @@ class Query {
 
     function _ts() {
         if($this->start_time instanceof \DateTime) {
-            return $this->start_time->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+            return $this->start_time->format('Y-m-d H:i:s');
         } else {
             return '';
         }
@@ -91,7 +91,7 @@ class Query {
 
     function _tsTo() {
         if($this->end_time instanceof \DateTime) {
-            return $this->end_time->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+            return $this->end_time->format('Y-m-d H:i:s');
         } else {
             return '';
         }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -85,20 +85,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($q->request_parameters()['tsTo'], '2012-12-28 09:01:22');
     }
 
-    function testQueryShouldConvertAddStartTime(){
-        $q = $this->client->query();
-        $q->pattern = 'spotify';
-        $q->start_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22', new \DateTimeZone('Europe/Moscow'));
-        $this->assertEquals($q->request_parameters()['ts'], '2012-12-28 05:01:22');
-    }
-
-    function testQueryShouldConvertEndTime(){
-        $q = $this->client->query();
-        $q->pattern = 'spotify';
-        $q->end_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22', new \DateTimeZone('Europe/Moscow'));
-        $this->assertEquals($q->request_parameters()['tsTo'], '2012-12-28 05:01:22');
-    }
-
     function testQueryShouldEncodeUrlParameters() {
         $q = $this->client->query();
         $q->pattern = 'spotify';


### PR DESCRIPTION
setTimezone() has side consequences, we will implement this with setters later.

Illustrated by:

```
$ ./vendor/bin/phpunit
PHPUnit 5.1.7 by Sebastian Bergmann and contributors.

.........................F.....                                   31 / 31 (100%)

Time: 3.52 seconds, Memory: 137.50Mb

There was 1 failure:

1) Twingly\Tests\QueryTest::testQueryShouldConvertAddStartTime
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'UTC'
+'Europe/Moscow'

/Users/dentarg/twingly/twingly-search-api-php/tests/QueryTest.php:94

FAILURES!
Tests: 31, Assertions: 50, Failures: 1.
```

``` diff
$ git d
diff --git a/tests/QueryTest.php b/tests/QueryTest.php
index 9ac37c6..ae8d898 100644
--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -88,8 +88,10 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
     function testQueryShouldConvertAddStartTime(){
         $q = $this->client->query();
         $q->pattern = 'spotify';
-        $q->start_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22', new \DateTimeZone('Europe/Moscow'));
+        $tmp = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22', new \DateTimeZone('Europe/Moscow'));
+        $q->start_time = $tmp;
         $this->assertEquals($q->request_parameters()['ts'], '2012-12-28 05:01:22');
+        $this->assertEquals($tmp->getTimezone()->getName(), 'Europe/Moscow');
     }
```
