### PR TITLE
Improve function/variable names

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,11 +28,11 @@ class Client {
     function __construct($api_key = false, $user_agent = false)
     {
         if(!$api_key) {
-            $api_key = $this->_env_api_key();
+            $api_key = $this->env_api_key();
         }
 
         if(!$api_key) {
-            $this->_api_key_missing();
+            $this->api_key_missing();
         }
 
         $this->api_key = $api_key;
@@ -73,7 +73,7 @@ class Client {
      * @throws ServerException
      */
     public function execute_query($query) {
-        $response_body = $this->_get_response($query)->getBody();
+        $response_body = $this->get_response($query)->getBody();
         $parser = new Parser();
         return $parser->parse($response_body);
     }
@@ -85,11 +85,11 @@ class Client {
         return sprintf('%s%s', Client::BASE_URL, Client::SEARCH_PATH);
     }
 
-    private function _env_api_key() {
+    private function env_api_key() {
         return getenv('TWINGLY_SEARCH_KEY');
     }
 
-    private function _get_response($query) {
+    private function get_response($query) {
         $response = $this->guzzle->get($query->url());
         if(($response->getStatusCode() >= 200)&&($response->getStatusCode() < 300)) {
             return $response;
@@ -102,7 +102,7 @@ class Client {
         }
     }
 
-    private function _api_key_missing() {
+    private function api_key_missing() {
         throw new AuthException('No API key has been provided.');
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ class Client {
     const DEFAULT_USER_AGENT = 'Twingly Search PHP Client/%s';
 
     public $api_key = null;
-    public $_user_agent = null;
+    public $user_agent = null;
     public $guzzle;
 
     /**
@@ -40,14 +40,14 @@ class Client {
         if(!$user_agent) {
             $user_agent = sprintf(Client::DEFAULT_USER_AGENT, Client::VERSION);
         }
-        $this->_user_agent = $user_agent;
+        $this->user_agent = $user_agent;
 
         $this->guzzle = new \GuzzleHttp\Client([
             'base_uri' => Client::BASE_URL,
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
-                'User-Agent' => $this->_user_agent
+                'User-Agent' => $this->user_agent
             ],
             'verify' => false
         ]);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,10 +28,10 @@ class Parser {
             }
         }
 
-        return $this->_create_result($doc);
+        return $this->create_result($doc);
     }
 
-    private function _create_result($data_node) {
+    private function create_result($data_node) {
         $result = new Result();
 
         $result->number_of_matches_returned = (int)$data_node->attributes()->numberOfMatchesReturned;
@@ -41,20 +41,20 @@ class Parser {
         $result->posts = [];
 
         foreach($data_node->xpath('//post[@contentType="blog"]') as $p) {
-            $result->posts[] = $this->_parse_post($p);
+            $result->posts[] = $this->parse_post($p);
         }
 
         return $result;
     }
 
-    private function _parse_post($element) {
+    private function parse_post($element) {
         $post_params = [
             'tags' => []
         ];
 
         foreach($element->children() as $child) {
             if($child->getName() == 'tags') {
-                $post_params[$child->getName()] = $this->_parse_tags($child);
+                $post_params[$child->getName()] = $this->parse_tags($child);
             } else {
                 $post_params[$child->getName()] = (string)$child;
             }
@@ -65,7 +65,7 @@ class Parser {
         return $post;
     }
 
-    private function _parse_tags($element) {
+    private function parse_tags($element) {
         $tags = [];
         foreach($element->xpath('//tag') as $tag) {
             $tags[] = (string)$tag;
@@ -73,12 +73,12 @@ class Parser {
         return $tags;
     }
 
-    private function _handle_failure($failure) {
+    private function handle_failure($failure) {
         $ex = new \Twingly\Exception();
         $ex->from_api_response_message($failure);
     }
 
-    private function _handle_non_xml_document($document){
+    private function handle_non_xml_document($document){
         $response_text = (string)$document->xpath('//text()')[0];
         throw new \Twingly\ServerException($response_text);
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -15,12 +15,12 @@ class Parser {
         $doc = simplexml_load_string($document);
 
         if($doc->getName() == 'html') {
-            $this->_handle_non_xml_document($doc);
+            $this->handle_non_xml_document($doc);
         }
 
         if(isset($doc->operationResult)) {
             if((string)$doc->operationResult->attributes()->resultType == 'failure') {
-                $this->_handle_failure((string)$doc->operationResult);
+                $this->handle_failure((string)$doc->operationResult);
             }
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -75,13 +75,13 @@ class Query {
             'key' => $this->client->api_key,
             'searchpattern' => $this->pattern,
             'documentlang' => $this->language,
-            'ts' => $this->_ts(),
-            'tsTo' => $this->_tsTo(),
+            'ts' => $this->ts(),
+            'tsTo' => $this->tsTo(),
             'xmloutputversion' => 2
         ];
     }
 
-    function _ts() {
+    function ts() {
         if($this->start_time instanceof \DateTime) {
             return $this->start_time->format('Y-m-d H:i:s');
         } else {
@@ -89,7 +89,7 @@ class Query {
         }
     }
 
-    function _tsTo() {
+    function tsTo() {
         if($this->end_time instanceof \DateTime) {
             return $this->end_time->format('Y-m-d H:i:s');
         } else {

--- a/src/Query.php
+++ b/src/Query.php
@@ -76,7 +76,7 @@ class Query {
             'searchpattern' => $this->pattern,
             'documentlang' => $this->language,
             'ts' => $this->ts(),
-            'tsTo' => $this->tsTo(),
+            'tsTo' => $this->ts_to(),
             'xmloutputversion' => 2
         ];
     }
@@ -89,7 +89,7 @@ class Query {
         }
     }
 
-    function tsTo() {
+    function ts_to() {
         if($this->end_time instanceof \DateTime) {
             return $this->end_time->format('Y-m-d H:i:s');
         } else {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 
     public function testNew() {
         $c = new Client('test-key');
-        $this->assertEquals($c->_user_agent, sprintf(Client::DEFAULT_USER_AGENT, Client::VERSION));
+        $this->assertEquals($c->user_agent, sprintf(Client::DEFAULT_USER_AGENT, Client::VERSION));
     }
 
     public function testWithoutApiKeyAsParameter() {
@@ -44,7 +44,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 
     public function testWithOptionalUserAgentGiven() {
         $c = new Client(false, 'Test User-Agent');
-        $this->assertEquals($c->_user_agent, 'Test User-Agent');
+        $this->assertEquals($c->user_agent, 'Test User-Agent');
     }
 
     public function testQuery() {


### PR DESCRIPTION
- No more leading underscores in variable/function names (#10)
- Always use snake_case. (All tests are named with CamelCase though, but their examples are in camelCase. Different libraries/frameworks has different conventions: http://programmers.stackexchange.com/a/196463)
