### PR TITLE
Include timezone info for timestamps in query

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -103,7 +103,7 @@ class Query {
         if($datetime instanceof \DateTime) {
             $datetime_copy = clone $datetime;
             $datetime_copy->setTimezone(new \DateTimeZone('UTC'));
-            return $datetime_copy->format('Y-m-d\TH:i:s');
+            return $datetime_copy->format('Y-m-d\TH:i:s\Z');
         } else {
             return '';
         }

--- a/src/Query.php
+++ b/src/Query.php
@@ -91,15 +91,15 @@ class Query {
             trigger_error('Query#language is deprecated, include it in search_query instead', E_USER_DEPRECATED);
             $search_query .= ' lang:' . $this->language;
         }
-        $search_query .= !empty($this->start_time) ? ' start-date:' . $this->datetime_to_utc_string($this->start_time) : '';
-        $search_query .= !empty($this->end_time) ? ' end-date:' . $this->datetime_to_utc_string($this->end_time) : '';
+        $search_query .= !empty($this->start_time) ? ' start-date:' . $this->datetime_to_iso8601_utc_string($this->start_time) : '';
+        $search_query .= !empty($this->end_time) ? ' end-date:' . $this->datetime_to_iso8601_utc_string($this->end_time) : '';
         return [
             'apikey' => $this->client->api_key,
             'q' => $search_query
         ];
     }
 
-    private function datetime_to_utc_string($datetime) {
+    private function datetime_to_iso8601_utc_string($datetime) {
         if($datetime instanceof \DateTime) {
             $datetime_copy = clone $datetime;
             $datetime_copy->setTimezone(new \DateTimeZone('UTC'));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -62,14 +62,14 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
         $q = $this->client->query();
         $q->search_query = 'spotify';
         $q->start_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22');
-        $this->assertContains('start-date:2012-12-28T09:01:22', $q->request_parameters()['q']);
+        $this->assertContains('start-date:2012-12-28T09:01:22Z', $q->request_parameters()['q']);
     }
 
     function testQueryWithStartTimeInTimezoneOtherThanUtc(){
         $q = $this->client->query();
         $q->search_query = 'spotify';
         $q->start_time = \DateTime::createFromFormat('Y-m-d H:i:s P', '2012-12-28 09:01:22 +01:00');
-        $this->assertContains('start-date:2012-12-28T08:01:22', $q->request_parameters()['q']);
+        $this->assertContains('start-date:2012-12-28T08:01:22Z', $q->request_parameters()['q']);
     }
 
     function testStartTimeUtcConversionDoesntModifyOriginalObject(){
@@ -84,14 +84,14 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
         $q = $this->client->query();
         $q->search_query = 'spotify';
         $q->end_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22');
-        $this->assertContains('end-date:2012-12-28T09:01:22', $q->request_parameters()['q']);
+        $this->assertContains('end-date:2012-12-28T09:01:22Z', $q->request_parameters()['q']);
     }
 
     function testQueryWithEndTimeInTimezoneOtherThanUtc(){
         $q = $this->client->query();
         $q->search_query = 'spotify';
         $q->end_time = \DateTime::createFromFormat('Y-m-d H:i:s P', '2012-12-28 09:01:22 +01:00');
-        $this->assertContains('end-date:2012-12-28T08:01:22', $q->request_parameters()['q']);
+        $this->assertContains('end-date:2012-12-28T08:01:22Z', $q->request_parameters()['q']);
     }
 
     function testEndTimeUtcConversionDoesntModifyOriginalObject(){
@@ -106,7 +106,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
         $q = $this->client->query();
         $q->search_query = 'spotify';
         $q->end_time = \DateTime::createFromFormat('Y-m-d H:i:s', '2012-12-28 09:01:22');
-        $this->assertContains('end-date%3A2012-12-28T09%3A01%3A22', $q->url_parameters());
+        $this->assertContains('end-date%3A2012-12-28T09%3A01%3A22Z', $q->url_parameters());
     }
 
     function testQueryPattern() {


### PR DESCRIPTION
Make sure the server knows which timezone the timestamps has. The same change as in twingly/twingly-search-api-ruby#67