### PR TITLE
Attempt to use correct phpunit binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ php:
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
-script: phpunit
+script: composer test
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
     "psr-4": {
       "Twingly\\": "src"
     }
+  },
+  "scripts": {
+    "test": "phpunit"
   }
 }


### PR DESCRIPTION
Prior to this [it fails](https://travis-ci.org/twingly/twingly-search-api-php/jobs/458755657) on:

```
$ phpunit
PHPUnit 7.3.5 by Sebastian Bergmann and contributors.

This version of PHPUnit is supported on PHP 7.1 and PHP 7.2.
You are using PHP 7.0.32 (/home/travis/.phpenv/versions/7.0.32/bin/php).
```

I.e: it does not use the `phpunit` version defined in our `composer.json` file.