### PR TITLE
PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ To learn more about the capabilities of the API, please read the [Twingly Search
 
 Install PHP and [Composer], on OS X:
 
-    brew tap homebrew/php
-    brew install php70    # or another supported version
+    brew install php@7.1
     brew install composer
 
 Install project dependencies:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "guzzlehttp/guzzle": "~6"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.1.*",
+    "phpunit/phpunit": "5.7.*",
     "php-vcr/php-vcr": "1.2.*",
     "phpdocumentor/phpdocumentor": "2.*"
   },

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -28,15 +28,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($q instanceof Query);
     }
 
-    function testQueryWithoutClient() {
-        try {
-            $q = new Query();
-            $this->fail('Should throw Extension');
-        } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \Exception);
-        }
-    }
-
     function testQueryWithoutSearchPattern() {
         try {
             $q = $this->client->query();


### PR DESCRIPTION
It's not possible to get PHP 7.0 via brew anymore, so let's see how we fare with PHP 7.1.

TODO:

- [x] Update README