### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Build Status](https://github.com/twingly/twingly-search-api-php/workflows/CI/badge.svg?branch=master)](https://github.com/twingly/twingly-search-api-php/actions)
 
-A PHP library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API](https://developer.twingly.com/resources/search/).
+A PHP library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API][Twingly Search API documentation].
 
 ## Installation
 
@@ -41,7 +41,9 @@ phpdoc -d ./src -t ./docs
 
 Example code can be found in [examples/](examples/).
 
-To learn more about the capabilities of the API, please read the [Twingly Search API documentation](https://developer.twingly.com/resources/search/).
+To learn more about the capabilities of the API, please read the [Twingly Search API documentation].
+
+[Twingly Search API documentation]: https://app.twingly.com/blog_search?tab=documentation
 
 ## Requirements
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -92,12 +92,12 @@ class Post {
     public $blog_name = '';
     /**
      * @var int the blog's authority/influence
-     *          (https://developer.twingly.com/resources/ranking/#authority)
+     *          (https://app.twingly.com/blog_search?tab=documentation)
      */
     public $authority = 0;
     /**
      * @var int the rank of the blog, based on authority and language
-     *          (https://developer.twingly.com/resources/ranking/#blogrank)
+     *          (https://app.twingly.com/blog_search?tab=documentation)
      */
     public $blog_rank = 0;
 


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.

I didn't link to the specific documentation sections in the code, just so we don't need to update the links in case we restructure the documentation in the future.