### PR TITLE
Make sure composer.json file works with newer Composer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
   },
   "scripts": {
     "test": "phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "symfony/flex": true
+    }
   }
 }


### PR DESCRIPTION
The builds in https://github.com/twingly/twingly-search-api-php/pull/35#issuecomment-1361177173 failed with the following message:

    Error: symfony/flex contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
    You can run "composer config --no-plugins allow-plugins.symfony/flex [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
    See https://getcomposer.org/allow-plugins

    In PluginManager.php line 738:

      symfony/flex contains a Composer plugin which is blocked by your allow-plug
      ins config. You may add it to the list if you consider it safe.
      You can run "composer config --no-plugins allow-plugins.symfony/flex [true|
      false]" to enable it (true) or disable it explicitly and suppress this exce
      ption (false)
      See https://getcomposer.org/allow-plugins

Turns out it's `phpdocumentor` that uses `symfony/flex` in some way:

    $ composer why symfony/flex
    phpdocumentor/phpdocumentor  v3.1.2  requires  symfony/flex (^1.3.1)

The error message happens because of a new security-related feature in composer, as documented on https://getcomposer.org/doc/06-config.md#allow-plugins

I fixed this by just running `composer install` and following the instructions:

    $ composer install
    symfony/flex contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
    Do you trust "symfony/flex" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
    [...]