### PR TITLE
Run CI on latest PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [8.1, 8.2, 8.3]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
These are the currently active PHP versions. See https://www.php.net/supported-versions.php.